### PR TITLE
Handle case when containerStatusMessage is "Created"

### DIFF
--- a/src/dockerSubMenuMenuItem.js
+++ b/src/dockerSubMenuMenuItem.js
@@ -34,7 +34,7 @@ const DockerSubMenuMenuItem = new Lang.Class({
         let gicon = Gio.icon_new_for_string(Me.path + "/icons/circle_red.png");
 
         // Docker container is not running
-        if(containerStatusMessage.indexOf("Exited") > -1) {
+        if(containerStatusMessage.indexOf("Exited") > -1 || containerStatusMessage.indexOf("Created") > -1) {
             this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, "start"));
         }
         // Docker container is up


### PR DESCRIPTION
When using Docker version 1.12.1, build 23cf638 on Arch linux the
containerStatusMessage was coming back as Created which uptil this
patch was preventing the extension from loading