### PR TITLE
Declare support for additional GNOME versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,11 @@
     "3.18",
     "3.20",
     "3.21",
-    "3.22"
+    "3.22",
+    "3.24",
+    "3.26",
+    "3.28",
+    "3.30"
   ],
   "description": "A status menu for managing docker containers.",
   "name": "Docker Integration",


### PR DESCRIPTION
This extension works on at least 3.28 and 3.30, so declare support for
those. I believe it also supports 3.24 and 3.26, but I have not
personally verified that. If anyone can verify that it works on 3.32,
I'd be happy to add that version here, as well.

See also: #35.