### PR TITLE
Address deprecation warnings

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -20,6 +20,9 @@
 
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+const Utils = Me.imports.src.utils;
 
 /**
  * Dictionary for Docker actions
@@ -108,12 +111,16 @@ var isDockerRunning = () => {
     let hasLine = true;
     do {
         const [out, size] = outReader.read_line(null);
-        if (out && out.toString().indexOf("docker") > -1) {
-            dockerRunning = true;
+
+        if (out) {
+            const outString = Utils.getByteArrayString(out);
+
+            if (outString && outString.indexOf("docker") > -1) {
+                dockerRunning = true;
+            }
         } else if (size <= 0) {
             hasLine = false;
         }
-
     } while (!dockerRunning && hasLine);
 
     return dockerRunning;

--- a/src/dockerMenu.js
+++ b/src/dockerMenu.js
@@ -41,8 +41,8 @@ var DockerMenu = class DockerMenu extends PanelMenu.Button {
         const dockerIcon = new St.Icon({ gicon: gicon, icon_size: "24" });
 
         hbox.add_child(dockerIcon);
-        this.actor.add_child(hbox);
-        this.actor.connect("button_press_event", this._refreshMenu.bind(this));
+        this.add_child(hbox);
+        this.connect("button_press_event", this._refreshMenu.bind(this));
 
         this._renderMenu();
     }
@@ -71,7 +71,7 @@ var DockerMenu = class DockerMenu extends PanelMenu.Button {
             this.menu.addMenuItem(new PopupMenu.PopupMenuItem(errMsg));
             log(errMsg);
         }
-        this.actor.show();
+        this.show();
     }
 
     // Append containers to menu

--- a/src/dockerMenu.js
+++ b/src/dockerMenu.js
@@ -18,9 +18,8 @@
 
 'use strict';
 
-const St = imports.gi.St;
-const Gio = imports.gi.Gio;
-const GObject = imports.gi.GObject;
+const { Clutter, St, Gio, GObject } = imports.gi;
+
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const ExtensionUtils = imports.misc.extensionUtils;
@@ -36,14 +35,16 @@ var DockerMenu = class DockerMenu extends PanelMenu.Button {
     _init() {
         super._init(0.0, _("Docker containers"));
 
+        this.clutterActor = this instanceof Clutter.Actor ? this : this.actor;
+
         const hbox = new St.BoxLayout({ style_class: "panel-status-menu-box" });
         const gicon = Gio.icon_new_for_string(Me.path + "/docker.svg");
         const dockerIcon = new St.Icon({ gicon: gicon, icon_size: "24" });
 
         hbox.add_child(dockerIcon);
-        this.add_child(hbox);
-        this.connect("button_press_event", this._refreshMenu.bind(this));
-
+        this.clutterActor.add_child(hbox);
+        this.clutterActor.connect("button_press_event", this._refreshMenu.bind(this));
+        
         this._renderMenu();
     }
 
@@ -71,7 +72,7 @@ var DockerMenu = class DockerMenu extends PanelMenu.Button {
             this.menu.addMenuItem(new PopupMenu.PopupMenuItem(errMsg));
             log(errMsg);
         }
-        this.show();
+        this.clutterActor.show();
     }
 
     // Append containers to menu

--- a/src/dockerSubMenuMenuItem.js
+++ b/src/dockerSubMenuMenuItem.js
@@ -60,23 +60,23 @@ var DockerSubMenuMenuItem = class DockerSubMenuMenuItem extends PopupMenu.PopupS
 
         switch (getStatus(containerStatusMessage)) {
             case "stopped":
-                this.actor.insert_child_at_index(createIcon('process-stop-symbolic', 'status-stopped'), 1);
+                this.insert_child_at_index(createIcon('process-stop-symbolic', 'status-stopped'), 1);
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.START));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.REMOVE));
                 break;
             case "running":
-                this.actor.insert_child_at_index(createIcon('system-run-symbolic', 'status-running'), 1);
+                this.insert_child_at_index(createIcon('system-run-symbolic', 'status-running'), 1);
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.OPEN_SHELL));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.RESTART));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.PAUSE));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.STOP));
                 break;
             case "paused":
-                this.actor.insert_child_at_index(createIcon('media-playback-pause-symbolic', 'status-paused'), 1);
+                this.insert_child_at_index(createIcon('media-playback-pause-symbolic', 'status-paused'), 1);
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.UNPAUSE));
                 break;
             default:
-                this.actor.insert_child_at_index(createIcon('action-unavailable-symbolic', 'status-undefined'), 1);
+                this.insert_child_at_index(createIcon('action-unavailable-symbolic', 'status-undefined'), 1);
                 break;
         }
     }

--- a/src/dockerSubMenuMenuItem.js
+++ b/src/dockerSubMenuMenuItem.js
@@ -18,8 +18,7 @@
 
 'use strict';
 
-const St = imports.gi.St;
-const GObject = imports.gi.GObject;
+const { Clutter, GObject, St } = imports.gi;
 const Lang = imports.lang;
 const PopupMenu = imports.ui.popupMenu;
 const ExtensionUtils = imports.misc.extensionUtils;
@@ -57,26 +56,28 @@ var DockerSubMenuMenuItem = class DockerSubMenuMenuItem extends PopupMenu.PopupS
 
     _init(containerName, containerStatusMessage) {
         super._init(containerName);
+        
+        this.clutterActor = this instanceof Clutter.Actor ? this : this.actor;
 
         switch (getStatus(containerStatusMessage)) {
             case "stopped":
-                this.insert_child_at_index(createIcon('process-stop-symbolic', 'status-stopped'), 1);
+                this.clutterActor.insert_child_at_index(createIcon('process-stop-symbolic', 'status-stopped'), 1);
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.START));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.REMOVE));
                 break;
             case "running":
-                this.insert_child_at_index(createIcon('system-run-symbolic', 'status-running'), 1);
+                this.clutterActor.insert_child_at_index(createIcon('system-run-symbolic', 'status-running'), 1);
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.OPEN_SHELL));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.RESTART));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.PAUSE));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.STOP));
                 break;
             case "paused":
-                this.insert_child_at_index(createIcon('media-playback-pause-symbolic', 'status-paused'), 1);
+                this.clutterActor.insert_child_at_index(createIcon('media-playback-pause-symbolic', 'status-paused'), 1);
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.UNPAUSE));
                 break;
             default:
-                this.insert_child_at_index(createIcon('action-unavailable-symbolic', 'status-undefined'), 1);
+                this.clutterActor.insert_child_at_index(createIcon('action-unavailable-symbolic', 'status-undefined'), 1);
                 break;
         }
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 /*
  * Gnome3 Docker Menu Extension
- * Copyright (C) 2017 Guillaume Pouilloux <gui.pouilloux@gmail.com>
+ * Copyright (C) 2020 Guillaume Pouilloux <gui.pouilloux@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,8 @@
 
 'use strict';
 
+const ByteArray = imports.byteArray;
+const GLib = imports.gi.GLib;
 const Config = imports.misc.config;
 
 var isGnomeShellVersionLegacy = () => {
@@ -26,4 +28,28 @@ var isGnomeShellVersionLegacy = () => {
 
     return gnomeShellMajor < 3 ||
         (gnomeShellMajor === 3 && gnomeShellMinor < 30);
+};
+
+/**
+ * Run a function in asynchronous mode using GLib
+ * @param {Function} fn The function to run
+ * @param {Function} callback The callback to call after fn
+ */
+var async = (fn, callback) => GLib.timeout_add(GLib.PRIORITY_DEFAULT, 0, () => callback(fn()));
+
+/**
+ * Return a string representation of the given byteArray
+ * 
+ * This is necessary for compatibility with older Gnome Shell versions,
+ * where GJS introspected methods handed back instances of the custom ByteArray
+ * type. Newer versions replace this behaviour by having methods return
+ * instances of JS Uint8Array type, whose "toString" method has a different
+ * purpose, hence an explicit call to ByteArray toString method is required.
+ * @param {Uint8Array|ByteArray} byteArray
+ * @return {String} The string representation of byteArray
+ */
+var getByteArrayString = (byteArray) => {
+    return byteArray instanceof Uint8Array ?
+        ByteArray.toString(byteArray)
+        : byteArray.toString();
 };


### PR DESCRIPTION
Hello, I went on to fix the problems reported in #54, here is a brief summary:

### ByteArray string representation
Calls to ByteArray toString method have been made explicit on Uint8Array objects returned by GLib functions. Compatibility with older Gnome Shell versions has been kept by checking the object type and invoking the method in the correct way.

### Actor property on UI classes
Access to `actor` property belonging to UI classes instances has been replaced by direct access to the instances. This has been done for both DockerMenu as well as DockerSubMenuMenuItem, whose superclasses have now become Clutter actors themselves.

Actually, the warning appeared only for the first of the two classes, but digging inside the library source code for UI elements I found out that the case must be the same for both of the two base classes (namely, PanelMenu.Button and PopupMenu.PopupSubMenuMenuItem), as this exists on the second one, explaining the absence of the warning message:

```javascript
get actor() {
        /* This is kept for compatibility with current implementation, and we
           don't want to warn here yet since PopupMenu depends on this */
        return this;
    }
```

I hope you'll find this clear enough and acceptable as well, as always I'll be happy to clarify a bit more or investigate further if needed.

Thank you!