### PR TITLE
Add confirmation on container remove

### DIFF
--- a/src/confirmationModal.js
+++ b/src/confirmationModal.js
@@ -29,21 +29,25 @@ const Utils = Me.imports.src.utils;
 
 var ConfirmationModal = class ConfirmationModal extends ModalDialog.ModalDialog {
 
-    _init(message, action, actionParams = []) {
+    _init(message, callback, callbackParams = []) {
         super._init();
 
-        this.action = action;
-        this.actionParams = actionParams;
+        this.message = message;
+        this.callback = callback;
+        this.callbackParams = callbackParams;
 
-        this._buildLayout(message);
+        this._buildLayout();
         this.open();
     }
 
-    _buildLayout(message) {
-        const content = new Dialog.MessageDialogContent({
-            title: "Confirm action",
-            description: message
-        });
+    _buildLayout() {
+        const messageDialogContentParams = {
+            title: "Confirm action"
+        };
+        Dialog.MessageDialogContent.prototype.hasOwnProperty("description")
+            ? messageDialogContentParams.description = this.message
+            : messageDialogContentParams.subtitle = this.message;
+        const content = new Dialog.MessageDialogContent(messageDialogContentParams);
         this.contentLayout.add_actor(content);
 
         const cancelButton = {
@@ -54,19 +58,14 @@ var ConfirmationModal = class ConfirmationModal extends ModalDialog.ModalDialog 
         };
         const confirmButton = {
             label: _("Confirm"),
-            action: Lang.bind(this, this._confirmAction),
-            key: Clutter.KEY_Return || Clutter.Return
+            action: Lang.bind(this, this._confirmAction)
         };
         this.setButtons([cancelButton, confirmButton]);
     }
 
-    _runAction() {
-        this.action(...this.actionParams);
-    }
-
     _confirmAction() {
         this.close();
-        this._runAction();
+        this.callback(...this.callbackParams);
     }
 
     _cancelAction() {

--- a/src/confirmationModal.js
+++ b/src/confirmationModal.js
@@ -1,0 +1,82 @@
+/*
+ * Gnome3 Docker Menu Extension
+ * Copyright (C) 2017 Guillaume Pouilloux <gui.pouilloux@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+'use strict';
+
+const Lang = imports.lang;
+const Clutter = imports.gi.Clutter;
+const GObject = imports.gi.GObject;
+const Dialog = imports.ui.dialog;
+const ModalDialog = imports.ui.modalDialog;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+const Utils = Me.imports.src.utils;
+
+var ConfirmationModal = class ConfirmationModal extends ModalDialog.ModalDialog {
+
+    _init(message, action, actionParams = []) {
+        super._init();
+
+        this.action = action;
+        this.actionParams = actionParams;
+
+        this._buildLayout(message);
+        this.open();
+    }
+
+    _buildLayout(message) {
+        const content = new Dialog.MessageDialogContent({
+            title: "Confirm action",
+            description: message
+        });
+        this.contentLayout.add_actor(content);
+
+        const cancelButton = {
+            label: _("Cancel"),
+            action: Lang.bind(this, this._cancelAction),
+            key: Clutter.KEY_Escape || Clutter.Escape,
+            default: true
+        };
+        const confirmButton = {
+            label: _("Confirm"),
+            action: Lang.bind(this, this._confirmAction),
+            key: Clutter.KEY_Return || Clutter.Return
+        };
+        this.setButtons([cancelButton, confirmButton]);
+    }
+
+    _runAction() {
+        this.action(...this.actionParams);
+    }
+
+    _confirmAction() {
+        this.close();
+        this._runAction();
+    }
+
+    _cancelAction() {
+        this.close();
+    }
+}
+
+if (!Utils.isGnomeShellVersionLegacy()) {
+    ConfirmationModal = GObject.registerClass(
+        { GTypeName: 'ConfirmationModal' },
+        ConfirmationModal
+    );
+}

--- a/src/docker.js
+++ b/src/docker.js
@@ -28,12 +28,13 @@ const Utils = Me.imports.src.utils;
 /**
  * Dictionary for Docker actions
  * @readonly
- * @type {{Object.<String, {label: String, isInteractive: Boolean}>}}
+ * @type {{Object.<String, {label: String, isInteractive: Boolean, needsConfirmation: Boolean}>}}
  */
 var DockerActions = Object.freeze({
     START: {
         label: "Start",
-        isInteractive: false
+        isInteractive: false,
+        needsConfirmation: false
     },
     REMOVE: {
         label: "Remove",
@@ -42,23 +43,28 @@ var DockerActions = Object.freeze({
     },
     OPEN_SHELL: {
         label: "Open shell",
-        isInteractive: true
+        isInteractive: true,
+        needsConfirmation: false
     },
     RESTART: {
         label: "Restart",
-        isInteractive: false
+        isInteractive: false,
+        needsConfirmation: false
     },
     PAUSE: {
         label: "Pause",
-        isInteractive: false
+        isInteractive: false,
+        needsConfirmation: false
     },
     STOP: {
         label: "Stop",
-        isInteractive: false
+        isInteractive: false,
+        needsConfirmation: false
     },
     UNPAUSE: {
         label: "Unpause",
-        isInteractive: false
+        isInteractive: false,
+        needsConfirmation: false
     },
 });
 
@@ -184,16 +190,15 @@ const runInteractiveCommand = (dockerCommand, callback) => {
 var runAction = (dockerAction, containerName, callback) => {
     const dockerCommand = getDockerActionCommand(dockerAction, containerName);
 
-    const action = () => {
-        dockerAction.isInteractive ?
-            runInteractiveCommand(dockerCommand, callback)
-            : runBackgroundCommand(dockerCommand, callback);
-    };
+    const action = dockerAction.isInteractive
+        ? runInteractiveCommand
+        : runBackgroundCommand;
+    const actionParams = [ dockerCommand, callback ];
 
-    const label = dockerAction.label.toLowerCase();
-    dockerAction.needsConfirmation ?
-        new ConfirmationModal.ConfirmationModal(
-            "Are you sure you want to " + label + " " + containerName + " container?",
-            action
-        ) : action();
+    dockerAction.needsConfirmation
+        ? new ConfirmationModal.ConfirmationModal(
+            `Are you sure you want to ${dockerAction.label.toLowerCase()} ${containerName} container?`,
+            action,
+            actionParams
+        ) : action(...actionParams);
 };


### PR DESCRIPTION
Hello Guillaume,

here I am with the implementation of the confirmation dialog for the remove action.

I introduced a reusable component in a separate file, inheriting from Gnome Shell base ModalDialog, and added a new property to the actions dictionary, indicating whether an action needs the user to confirm for its execution.
I also started worrying a bit about the hierarchy of source files at this point, but haven't had any change yet. I thought that maybe it could be reorganized by placing UI components in a dedicated folder, like this:
```
- src
    - ui
        - confirmationModal.js
        - dockerMenu.js
        - dockerMenuItem.js
        - dockerMenuStatusItem.js
        - dockerSubMenuMenuItem.js
    - docker.js
    - utils.js
```

I tested it against gnome-shell 3.36.3 on Ubuntu 20.04 and 3.28.4 on Ubuntu 18.04, and haven't experienced any particular issue.

As always, consider the implementation as a draft, and please feel free to propose changes if you don't like something, you know I don't want to overcome your voice on structure decisions for the project!

Have a good weekend,
Alessandro