### PR TITLE
Some improvements for this Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ The following actions are available :
 - Remove
 - Pause
 - Stop
-- Stop and remove
 - Restart
 - Exec shell
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The following actions are available :
 - Remove
 - Pause
 - Stop
+- Stop and remove
 - Restart
 - Exec shell
 

--- a/src/docker.js
+++ b/src/docker.js
@@ -42,10 +42,6 @@ var DockerActions = Object.freeze({
         label: "Open shell",
         isInteractive: true
     },
-    STOP_AND_REMOVE: {
-        label: "Stop and remove",
-        isInteractive: false,
-    },
     RESTART: {
         label: "Restart",
         isInteractive: false
@@ -77,7 +73,7 @@ const getDockerActionCommand = (dockerAction, containerName) => {
         case DockerActions.START:
             return "docker start " + containerName;
         case DockerActions.REMOVE:
-            return "docker rm " + containerName + " --force";
+            return "docker rm --force " + containerName;
         case DockerActions.OPEN_SHELL:
             return "docker exec -it " + containerName + " /bin/bash; "
                 + "if [ $? -ne 0 ]; then docker exec -it " + containerName + " /bin/sh; fi;";
@@ -89,8 +85,6 @@ const getDockerActionCommand = (dockerAction, containerName) => {
             return "docker stop " + containerName;
         case DockerActions.UNPAUSE:
             return "docker unpause " + containerName;
-        case DockerActions.STOP_AND_REMOVE:
-              return "docker rm --force  " + containerName;
         default:
             throw new Error("Docker action not valid");
     }

--- a/src/docker.js
+++ b/src/docker.js
@@ -42,6 +42,10 @@ var DockerActions = Object.freeze({
         label: "Open shell",
         isInteractive: true
     },
+    STOP_AND_REMOVE: {
+        label: "Stop and remove",
+        isInteractive: false,
+    },
     RESTART: {
         label: "Restart",
         isInteractive: false
@@ -73,7 +77,7 @@ const getDockerActionCommand = (dockerAction, containerName) => {
         case DockerActions.START:
             return "docker start " + containerName;
         case DockerActions.REMOVE:
-            return "docker rm " + containerName;
+            return "docker rm " + containerName + " --force";
         case DockerActions.OPEN_SHELL:
             return "docker exec -it " + containerName + " /bin/bash; "
                 + "if [ $? -ne 0 ]; then docker exec -it " + containerName + " /bin/sh; fi;";
@@ -85,6 +89,8 @@ const getDockerActionCommand = (dockerAction, containerName) => {
             return "docker stop " + containerName;
         case DockerActions.UNPAUSE:
             return "docker unpause " + containerName;
+        case DockerActions.STOP_AND_REMOVE:
+              return "docker rm --force  " + containerName;
         default:
             throw new Error("Docker action not valid");
     }

--- a/src/dockerMenu.js
+++ b/src/dockerMenu.js
@@ -85,6 +85,7 @@ var DockerMenu = class DockerMenu extends PanelMenu.Button {
         try {
             const containers = Docker.getContainers();
             if (containers.length > 0) {
+                containers.sort(this._compareContainerNames);
                 containers.forEach(container => {
                     const subMenu = new DockerSubMenuMenuItem.DockerSubMenuMenuItem(
                         container.name,
@@ -103,6 +104,18 @@ var DockerMenu = class DockerMenu extends PanelMenu.Button {
             log(errMsg);
             log(err);
         }
+    }
+
+    _compareContainerNames( a, b ) {
+        if ( a.name < b.name ) {
+            return -1;
+        }
+
+        if ( a.name > b.name ) {
+            return 1;
+        }
+
+        return 0;
     }
 };
 

--- a/src/dockerMenu.js
+++ b/src/dockerMenu.js
@@ -28,6 +28,8 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Docker = Me.imports.src.docker;
 const DockerSubMenuMenuItem = Me.imports.src.dockerSubMenuMenuItem;
 const DockerMenuStatusItem = Me.imports.src.dockerMenuStatusItem;
+const DockerMenuStopContainersItem = Me.imports.src.dockerMenuStopContainersItem;
+
 const Utils = Me.imports.src.utils;
 
 // Docker icon on status menu
@@ -62,6 +64,12 @@ var DockerMenu = class DockerMenu extends PanelMenu.Button {
         if (Docker.isDockerInstalled()) {
             if (Docker.isDockerRunning()) {
                 this._feedMenu();
+
+                // Stop all containers
+                let stopAllContainersItem = new DockerMenuStopContainersItem.DockerMenuStopContainersItem('Stop all containers');
+                this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                this.menu.addMenuItem(stopAllContainersItem);
+
             } else {
                 let errMsg = _("Docker daemon not started");
                 this.menu.addMenuItem(new PopupMenu.PopupMenuItem(errMsg));
@@ -69,9 +77,9 @@ var DockerMenu = class DockerMenu extends PanelMenu.Button {
             }
 
             // Add Turn On / Turn Off Switch always
-			let statusSwitch = new DockerMenuStatusItem.DockerMenuStatusItem('Docker status');
-			this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-			this.menu.addMenuItem(statusSwitch);
+            let statusSwitch = new DockerMenuStatusItem.DockerMenuStatusItem('Docker status');
+            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            this.menu.addMenuItem(statusSwitch);
         } else {
             let errMsg = _("Docker binary not found in PATH ");
             this.menu.addMenuItem(new PopupMenu.PopupMenuItem(errMsg));

--- a/src/dockerMenuStopContainersItem.js
+++ b/src/dockerMenuStopContainersItem.js
@@ -39,7 +39,6 @@ var DockerMenuStopContainersItem = class DockerMenuStopContainersItem extends Po
         try{
             allContainers = Docker.getContainers();
         }catch (err) {
-            allContainers = [];
             log('Error while fetching docker containers')
             return;
         }

--- a/src/dockerMenuStopContainersItem.js
+++ b/src/dockerMenuStopContainersItem.js
@@ -1,0 +1,91 @@
+/*
+ * Gnome3 Docker Menu Extension
+ * Copyright (C) 2020 Guillaume Pouilloux <gui.pouilloux@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+'use strict';
+
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Main = imports.ui.main;
+const PopupMenu = imports.ui.popupMenu;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+const Docker = Me.imports.src.docker;
+const Utils = Me.imports.src.utils;
+
+var DockerMenuStopContainersItem = class DockerMenuStopContainersItem extends PopupMenu.PopupMenuItem {
+    _init(itemLabel, allContainers) {
+        super._init(itemLabel);
+
+        this.connect('activate', this._dockerAction.bind(this));
+    }
+
+    _dockerAction() {
+        let allContainers;
+        try{
+            allContainers = Docker.getContainers();
+        }catch (err) {
+            allContainers = [];
+            log('Error while fetching docker containers')
+            return;
+        }
+
+        for (let i=0;i< allContainers.length;i++) {
+            
+            if(this._isContainerStarted(allContainers[i].status) == false){
+                continue;
+            }
+
+            const dockerCmd = 'docker stop ' + allContainers[i].name;
+            Utils.async(
+                () => GLib.spawn_command_line_async(dockerCmd),
+                (res) => {
+                    if(!!res) {
+                        log('Docker container `' + allContainers[i].name + '` has been stopped.');
+                    } else {
+                        const errMsg = "Docker: error occurred when stopping container `" + allContainers[i].name + "`";
+
+                        Main.notify(errMsg);
+                        log(errMsg);
+                    }
+
+                    return GLib.SOURCE_REMOVE;
+                }
+            );
+        }
+    }
+
+
+    _isContainerStarted(status) {
+        if (status.indexOf('Up') > -1) {
+            return true;
+        }
+        if (status.indexOf('Paused') > -1) {
+            return true;
+        }
+
+        return false;
+
+    }
+};
+
+if (!Utils.isGnomeShellVersionLegacy()) {
+    DockerMenuStopContainersItem = GObject.registerClass(
+        { GTypeName: 'DockerMenuStopContainersItem' },
+        DockerMenuStopContainersItem
+    );
+}

--- a/src/dockerSubMenuMenuItem.js
+++ b/src/dockerSubMenuMenuItem.js
@@ -75,9 +75,12 @@ var DockerSubMenuMenuItem = class DockerSubMenuMenuItem extends PopupMenu.PopupS
             case "paused":
                 this.actor.insert_child_at_index(createIcon('media-playback-pause-symbolic', 'status-paused'), 1);
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.UNPAUSE));
+                this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.STOP));
+                this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.REMOVE));
                 break;
             default:
                 this.actor.insert_child_at_index(createIcon('action-unavailable-symbolic', 'status-undefined'), 1);
+                this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.REMOVE));
                 break;
         }
     }

--- a/src/dockerSubMenuMenuItem.js
+++ b/src/dockerSubMenuMenuItem.js
@@ -70,7 +70,7 @@ var DockerSubMenuMenuItem = class DockerSubMenuMenuItem extends PopupMenu.PopupS
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.RESTART));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.PAUSE));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.STOP));
-                this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.STOP_AND_REMOVE));
+                this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.REMOVE));
                 break;
             case "paused":
                 this.actor.insert_child_at_index(createIcon('media-playback-pause-symbolic', 'status-paused'), 1);

--- a/src/dockerSubMenuMenuItem.js
+++ b/src/dockerSubMenuMenuItem.js
@@ -70,6 +70,7 @@ var DockerSubMenuMenuItem = class DockerSubMenuMenuItem extends PopupMenu.PopupS
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.RESTART));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.PAUSE));
                 this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.STOP));
+                this.menu.addMenuItem(new DockerMenuItem.DockerMenuItem(containerName, DockerActions.STOP_AND_REMOVE));
                 break;
             case "paused":
                 this.actor.insert_child_at_index(createIcon('media-playback-pause-symbolic', 'status-paused'), 1);

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,5 +1,5 @@
 .status-undefined {
-
+    color:  gray;
 }
 
 .status-stopped {


### PR DESCRIPTION
I've added some improvements to this extension:

 - Add a new option for "Stop and Remove": Sometimes, I want to remove a container that is already started. So, instead of clicking on stop and then on remove, we have this new option "stop and remove";
 - Sort container names: When there are a lot of containers, it is kind of hard to find the one you want. I think if the container names are sorted, it is easier to find them;
 - Add --force when removing a container;
 - Display gray color when the status is undefined;